### PR TITLE
java8 compat in tests

### DIFF
--- a/src/test/java/io/findify/flinkpb/JobTest.java
+++ b/src/test/java/io/findify/flinkpb/JobTest.java
@@ -4,11 +4,12 @@ import io.findify.flinkprotobuf.java.Tests;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
+import java.util.Arrays;
 import java.util.List;
 
 public class JobTest {
     public static List<Tests.Foo> test(StreamExecutionEnvironment env) throws Exception {
         TypeInformation<Tests.Foo> ti = FlinkProtobuf.generateJava(Tests.Foo.class, Tests.Foo.getDefaultInstance());
-        return env.fromCollection(List.of(Tests.Foo.newBuilder().setValue(1).build()), ti).executeAndCollect(100);
+        return env.fromCollection(Arrays.asList(Tests.Foo.newBuilder().setValue(1).build()), ti).executeAndCollect(100);
     }
 }


### PR DESCRIPTION
As `List.of` is only available from Java 9.